### PR TITLE
Allow efa-device-plugin container to run as root

### DIFF
--- a/pkg/addons/assets/efa-device-plugin.yaml
+++ b/pkg/addons/assets/efa-device-plugin.yaml
@@ -155,7 +155,6 @@ spec:
         - image: "%s.dkr.ecr.%s.%s/eks/aws-efa-k8s-device-plugin:v0.3.3"
           name: aws-efa-k8s-device-plugin
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]


### PR DESCRIPTION
### Description

efa-device-plugin container need to run as root.
**This Commit is a follow up commit to #6065**.
It closes https://github.com/aws-samples/aws-efa-eks/issues/8.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

